### PR TITLE
Makes command-name and version "configurable"

### DIFF
--- a/app/junitdiff
+++ b/app/junitdiff
@@ -34,7 +34,8 @@ require JUNITDIFF_COMPOSER_INSTALL;
 use Symfony\Component\Console\Application;
 
 $app = new Application();
-$app->setName('JUnitDiff (%version%) by Andreas Heigl and contributors');
+$app->setVersion('0.2.0');
+$app->setName('JUnitDiff (by Andreas Heigl and contributors)');
 
 $app->add(new \Org_Heigl\JUnitDiff\Command\DiffCommand());
 $app->run();

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -49,7 +49,7 @@ class DiffCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln([
-            '<fg=yellow>JUnitDiff (%version%) by Andreas Heigl and contributors</>',
+            $this->getApplication()->getLongVersion(),
             '',
         ]);
 

--- a/tests/Command/DiffCommandTest.php
+++ b/tests/Command/DiffCommandTest.php
@@ -49,7 +49,7 @@ class DiffCommandTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->assertEquals('JUnitDiff (%version%) by Andreas Heigl and contributors
+        $this->assertEquals('Console Tool
 
 - Org_Heigl_HyphenatorTest::testHyphenateEntweder
 + Org_Heigl_HyphenatorTest::testHyphenatorSingletonReturnsHyphenatorObject


### PR DESCRIPTION
This Commit sets the command-name and the version separately and uses that string instead of a self-build string.

It extends PR #7 by also adding the version number to the console-output of the commands
