### PR TITLE
Improve Travis deploy process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
 before_install:
   - travis_retry composer self-update
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - if [[ $BUILD_PHAR == 'true' && $TRAVIS_TAG != '' ]]; then echo $DECRYPT_KEY | gpg --passphrase-fd 0 JUnitDiffSigning.asc.gpg && gpg --batch --yes --import JUnitDiffSigning.asc ; fi
 
 
 install:
@@ -29,11 +28,15 @@ install:
 
 script:
   - composer test
-  - if [[ $BUILD_PHAR == 'true' && $TRAVIS_TAG != '' ]]; then composer buildphar && echo $SIGN_KEY | gpg --passphrase-fd 0 -u AE11B9CEBADB342A --armor --detach-sig build/junitdiff.phar ; fi
+  - if [[ $BUILD_PHAR == 'true' && $TRAVIS_TAG != '' ]]; then composer buildphar; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' && $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then travis_retry vendor/bin/coveralls -v ; fi
   - if [[ $TEST_COVERAGE == 'true' && $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then vendor/bin/test-reporter --coverage-report=clover.xml ; fi
+
+before_deploy:
+  - echo $DECRYPT_KEY | gpg --passphrase-fd 0 JUnitDiffSigning.asc.gpg && gpg --batch --yes --import JUnitDiffSigning.asc
+  - echo $SIGN_KEY | gpg --passphrase-fd 0 -u AE11B9CEBADB342A --armor --detach-sig build/junitdiff.phar 
 
 deploy:
   provider: releases
@@ -44,4 +47,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    php: '7.0'
+    condition: $BUILD_PHAR


### PR DESCRIPTION
 * Use the before_deploy section to avoid verbose bash ifs
 * use the $BUILD_PHAR condition to enable the deploy

For now I've left the PHAR build in the script section, but it's build only on release, it's ok?